### PR TITLE
#002 FIX: Added an extra day to make_range, to be safe.

### DIFF
--- a/app/helpers/format_dates.py
+++ b/app/helpers/format_dates.py
@@ -3,7 +3,7 @@ from dateutil.relativedelta import relativedelta
 
 
 def make_range(config):
-    end_at = datetime.now().strftime("%Y-%m-%d")
+    end_at = (datetime.now() + relativedelta(days=1)).strftime("%Y-%m-%d")
     begin_at = (
         datetime.now() - relativedelta(months=config["inactive_duration_in_months"])
     ).strftime("%Y-%m-%d")


### PR DESCRIPTION
Hey @amedeomajer

This PR is here to fix the issue encountered by Codam with our script [Issue #002](https://github.com/hivehelsinki/home-cleaner/issues/2)

They ran the script the same day of the user was created on intranet and the functions `check_students_profile_creation_dates` didn't seem to include that user in `students_with_new_homes`

because `make_range` was creating a range from from `3 months ago to today` like so: `'2024-05-13,2024-08-13'`

However, when this is sent as payload to the intranet, they consider from midnight to midnight with such range so every account created after midnight of the same day was not included in the list

As a fix, I propose an extra day, but you could also use the exact current date by also passing hours, minutes, and seconds.

Up to you :) 

Please test that out before merging.