### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ COPY pyproject.toml poetry.lock /app/
 
 RUN poetry install --no-root
 
-COPY app/ /app/homecleaner/
+COPY app/ /app/app/
 COPY tests/ /app/tests/

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,8 @@ def get_inactive_students(students):
         logging.warning("No inactive students found. Exiting program.")
         exit()
 
+    logging.info(f"Found {len(inactive_students)} inactive students.")
+
     return inactive_students
 
 
@@ -90,7 +92,7 @@ def check_that_homes_are_deleted(deleted_homes):
     homes = get_homes()
     undeleted_homes = [home for home in deleted_homes if home in homes]
     if len(undeleted_homes) == 0:
-        logging.info("All homes are deleted.")
+        logging.info("All inactive homes are deleted.")
     else:
         logging.error(f"\033[0;31mFailed to delete {len(undeleted_homes)} homes:")
         logging.error(", ".join(undeleted_homes))

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,8 @@ services:
       environment:
         - HOMEMAKER_API=http://
       volumes:
-        - ./app:/app/homecleaner:z
+        - ./app:/app/app:z
         - ./tests:/app/tests:z
         - ./pyproject.toml:/app/pyproject.toml:z
         - ./poetry.lock:/app/poetry.lock:z
+        - ./config.yml:/app/config.yml:z


### PR DESCRIPTION
This PR fixes a ModuleNotFoundError caused by a wrong path to the app directory used in the Docker container.

Additionally, it solves a ConfigNotFoundError by mounting the config.yml file as a volume in the Docker container too.

Lastly it makes 2 logged lines somewhat more clear (I nearly got a heart attack when the program exited with `All homes are deleted`)